### PR TITLE
Add ollama v0.23.0

### DIFF
--- a/ansible/roles/compiled/tasks/common/main.yml
+++ b/ansible/roles/compiled/tasks/common/main.yml
@@ -1489,3 +1489,18 @@
   tags:
       - never
       - boost
+
+- name: Install Ollama
+  vars:
+    versions:
+      - {
+        version_number: "0.23.0",
+        checksum: "sha256:581ba6cc0c6da3e80f4f454c274a0260ba07095089a21692b165caba9bf49ad4",
+        url: "https://github.com/ollama/ollama/releases/download/v0.23.0/ollama-linux-amd64.tar.zst"
+      }
+  include_tasks:
+    file: 'ollama.yaml'
+  loop: "{{ versions }}"
+  tags:
+    - never
+    - ollama

--- a/ansible/roles/compiled/tasks/common/ollama.yaml
+++ b/ansible/roles/compiled/tasks/common/ollama.yaml
@@ -1,0 +1,41 @@
+---
+- name: Install ollama {{ item.version_number }}
+  vars:
+    ollama_dir: "{{ common_dir }}/ollama"
+    ollama_module_dir: "{{ common_modules }}/ollama"
+    url: "{{ item.url }}"
+    version_number: "{{ item.version_number }}"
+    checksum: "{{ item.checksum }}"
+    install_dir: "{{ ollama_dir }}/{{ version_number }}"
+  tags:
+    - never
+    - ollama{{ item.version_number }}
+
+  block:
+    - name: Download and install ollama {{ version_number }}
+      block:
+        - name: Download ollama {{ version_number }} from {{ url }}
+          get_url:
+            url: "{{ url }}"
+            dest: "{{ common_src }}/ollama-{{ version_number }}-linux-amd64.tar.zst"
+            checksum: "{{ checksum }}"
+        - name: Ensure ollama {{ version_number }} dir exists
+          file:
+            path: "{{ install_dir }}"
+            state: directory
+        - name: Uncompress ollama {{ version_number }}
+          command: "tar -I zstd -xf {{ common_src }}/ollama-{{ version_number }}-linux-amd64.tar.zst -C {{ install_dir }}"
+          args:
+            creates: "{{ install_dir }}/bin/ollama"
+
+    - name: Install ollama {{ version_number }} module
+      block:
+        - name: Check module dir {{ ollama_module_dir }}
+          file:
+            path: "{{ ollama_module_dir }}"
+            state: directory
+            mode: u=rwx,g=rwx,o=rx
+        - name: Install ollama module file
+          template:
+            src: ollama.lua
+            dest: "{{ ollama_module_dir }}/{{ version_number }}.lua"

--- a/ansible/roles/compiled/templates/ollama.lua
+++ b/ansible/roles/compiled/templates/ollama.lua
@@ -6,8 +6,6 @@ whatis("Version: {{ version_number }}")
 whatis("Keywords: ollama")
 whatis("Description: ollama {{ version_number }}: run large language models locally")
 
-local ollama_dir = "{{ install_dir }}"
-
 setenv('OLLAMA_MODELS', '/software/data/common/models')
 prepend_path('PATH', '{{ install_dir }}/bin')
 prepend_path('LD_LIBRARY_PATH', '{{ install_dir }}/lib')

--- a/ansible/roles/compiled/templates/ollama.lua
+++ b/ansible/roles/compiled/templates/ollama.lua
@@ -1,0 +1,13 @@
+-- -*- lua -*-
+help([[
+This module configures ollama {{ version_number }} for use
+]])
+whatis("Version: {{ version_number }}")
+whatis("Keywords: ollama")
+whatis("Description: ollama {{ version_number }}: run large language models locally")
+
+local ollama_dir = "{{ install_dir }}"
+
+setenv('OLLAMA_MODELS', '/software/data/common/models')
+prepend_path('PATH', '{{ install_dir }}/bin')
+prepend_path('LD_LIBRARY_PATH', '{{ install_dir }}/lib')


### PR DESCRIPTION
## Summary

- Adds Ollama v0.23.0 installation task to the compiled software role
- Downloads `ollama-linux-amd64.tar.zst` from GitHub releases and extracts using `tar -I zstd` directly into the versioned install directory (the tarball has no wrapper directory)
- Creates a Lmod module that sets `PATH`, `LD_LIBRARY_PATH`, and `OLLAMA_MODELS=/software/data/common/models`

## Test plan

- [ ] Run playbook with `--tags ollama` and verify no errors
- [ ] Confirm `module load ollama/0.23.0` resolves `ollama` on `PATH`
- [ ] Confirm `ollama --version` returns `0.23.0`
- [ ] Confirm models are pulled to `/software/data/common/models`
- [ ] Verify the sha256 checksum against the official `sha256sum.txt` from the v0.23.0 release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)